### PR TITLE
fixes jphalip/djangocore-box#11

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ Main author: Julien Phalip
 Contributors:
 - Ash Christopher
 - Jeremy Dunck
+- Joshua Sorenson

--- a/provisioning/shell/init-system.sh
+++ b/provisioning/shell/init-system.sh
@@ -47,3 +47,8 @@ fi
 if [ -e /home/vagrant/.hosthome/.gitignore ]; then
   ln -fs /home/vagrant/.hosthome/.gitignore /home/vagrant/.gitignore
 fi
+
+# Fixes issue #11
+if [ -e /home/vagrant/postinstall.sh ]; then 
+  rm -f /home/vagrant/postinstall.sh
+fi


### PR DESCRIPTION
Remove the postinstall.sh file after we've finsihed init-system.sh

This builds a box without postinstall.sh in the /home/vagrant directory. If rebuild/vagrant package this, you should have a base box without that file.

I also added myself to the authors file if that's okay.
